### PR TITLE
Added Kogge-Stone Adder

### DIFF
--- a/src/dut/ksa/config.py
+++ b/src/dut/ksa/config.py
@@ -1,0 +1,54 @@
+"""
+File: config.py
+Author: Erick Andres Obregon Fonseca
+Date: 2025-09-02
+Description: Configuration dictionary for the Kogge Stone Adder (KSA).
+License: MIT.
+
+This file defines the ``CONFIG`` dictionary, which provides metadata and build
+information for the cocotb test environment.
+
+Structure
+---------
+CONFIG : dict
+    'name' : str
+        Identifier for the DUT (e.g., "rca").
+    'top_module' : str
+        Name of the Verilog top-level module for the DUT.
+    'rtl_files' : list[str]
+        List of relative paths to the RTL source files.
+    'parameters' : dict[str, Any]
+        Parameter overrides for the DUT (e.g., bit-width N).
+    'ports' : dict[str, str]
+        Mapping of logical signal names (used in tests) to DUT port names.
+
+Notes
+-----
+- The parameter ``N`` (adder width) is chosen randomly from [4, 8, 16, 32] at
+  import time. This introduces variability in tests, but it also means each
+  run may have a different bit-width.
+- For reproducible regressions, consider fixing the random seed or replacing
+  the random choice with a fixed value.
+"""
+import random
+
+
+CONFIG = {
+    "name": "ksa",
+    "top_module": "ksa",
+    "rtl_files": [
+        "rtl/ksa.v",
+    ],
+    "parameters": {
+        # Bit-width of the adder; randomized at import time
+        "N": random.choice([4, 8, 16, 32]),
+    },
+    "ports": {
+        # Mapping of logical names (used in tests) to DUT port names
+        "a": "a",
+        "b": "b",
+        "c_in": "c_in",
+        "sum": "sum",
+        "c_out": "c_out",
+    },
+}

--- a/src/dut/ksa/rtl/ksa.v
+++ b/src/dut/ksa/rtl/ksa.v
@@ -1,0 +1,76 @@
+//----------------------------------------------------------------------------
+// Title        : Kogge Stone Adder (KSA)
+// File         : ksa.v
+// Date         : 2025-07-08
+// Author       : Erick Andrés Obregón Fonseca
+// Email        : erickof@ieee.org
+// Organization : ECASLAB
+// Description  : Kogge Stone adder, a parallel prefix adder that computes
+//                the sum and carry-out of two n-bit operands using a tree
+//                structure to reduce delay compared to ripple-carry and
+//                other adder architectures. This implementation is
+//                parameterized for N-bit inputs but can be extended to
+//                support wider operands by increasing the parameter N.
+// License      : MIT License (see LICENSE file for details)
+//----------------------------------------------------------------------------
+`timescale 1ns / 1ps
+
+module ksa #(
+  parameter int N = 4
+) (
+  input  wire [N-1:0] a,
+  input  wire [N-1:0] b,
+  input  wire         c_in,
+  output wire [N-1:0] sum,
+  output wire         c_out
+);
+  // bitwise generate/propagate (using XOR propagate form)
+  wire [N-1:0] g0 = a & b;
+  wire [N-1:0] p0 = a ^ b;
+
+  localparam int STAGES = $clog2(N);
+
+  // prefix matrices
+  wire [N-1:0] g [0:STAGES];
+  wire [N-1:0] p [0:STAGES];
+
+  // stage 0 seeds
+  assign g[0] = g0;
+  assign p[0] = p0;
+
+  genvar stage, i;
+  generate
+    for (stage = 0; stage < STAGES; stage = stage + 1) begin : gb_stage
+      for (i = 0; i < N; i = i + 1) begin : gen_g_p
+        if (i < (1 << stage)) begin
+          // pass-through (gray cell / buffer)
+          assign g[stage + 1][i] = g[stage][i];
+          assign p[stage + 1][i] = p[stage][i];
+        end else begin
+          // black cell combine
+          assign g[stage + 1][i] = g[stage][i] | (p[stage][i] & g[stage][i - (1 << stage)]);
+          assign p[stage + 1][i] = p[stage][i] & p[stage][i - (1 << stage)];
+        end
+      end
+    end
+  endgenerate
+
+  // Final prefix results are G/P over [i:0]
+  wire [N-1:0] G = g[STAGES];
+  wire [N-1:0] P = p[STAGES];
+
+  // Per-bit carries (carry into bit i+1). Incorporate c_in.
+  wire [N-1:0] c = G | (P & {N{c_in}});
+
+  // Sums: sum[0] uses c_in; sum[i] uses carry into bit i, which is c[i-1]
+  assign sum[0] = p0[0] ^ c_in;
+
+  genvar j;
+  generate
+    for (j = 1; j < N; j = j + 1) begin : gen_sum
+      assign sum[j] = p0[j] ^ c[j-1];
+    end
+  endgenerate
+
+  assign c_out = c[N-1];
+endmodule // ksa


### PR DESCRIPTION
### Kogge-Stone Adder Implementation

Introducing the Kogge-Stone adder (KSA). The Kogge-Stone adder is a parallel prefix form of carry-lookahead adder (CLA), widely recognized for its high performance and low logic depth, making it suitable for high-speed arithmetic operations in modern hardware designs.

#### Key Features:
- **Efficient Carry Propagation:** Utilizes parallel prefix computation for fast carry generation.
- **Scalable Architecture:** Easily adaptable to varying operand widths.
- **Optimised for Performance:** Reduces critical path delay compared to traditional adders.
- **Modular Design:** The implementation is structured for easy integration and testing within existing CGRA frameworks.

#### Files Added/Modified:
- Kogge-Stone adder source RTL files.
- Documentation or comments explaining core logic and usage.
- Testbench configuration file for test running.

#### Usage:
- Integrate the Kogge-Stone adder module in arithmetic datapaths where high-speed addition is crucial.
- Run provided testbenches to validate functionality and performance metrics.

#### References:
- Kogge, P. M., & Stone, H. S. (1973). A Parallel Algorithm for the Efficient Solution of a General Class of Recurrence Relations. IEEE Transactions on Computers.